### PR TITLE
Set portable library assembly option XamlCompilationOptions.Compile

### DIFF
--- a/ContosoCookbook/ContosoCookbook/ContosoCookbook/Properties/AssemblyInfo.cs
+++ b/ContosoCookbook/ContosoCookbook/ContosoCookbook/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Xamarin.Forms.Xaml;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -15,6 +16,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
+
+[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
 // Version information for an assembly consists of the following four values:
 //


### PR DESCRIPTION
According to James Montemagno's "The Xamarin Show 3: Xamarin.Forms Performance Tips and Tricks" on Channel 9 this is better because it's more performant. It also gives you compile-time XAML errors instead of runtime.