### PR TITLE
Example of how to use Prism's IDeviceService

### DIFF
--- a/18-DeviceService/ReadMe.md
+++ b/18-DeviceService/ReadMe.md
@@ -1,5 +1,5 @@
 # Device Service
 
-TODO
+This example shows
 
-- Show using the IDeviceService instead of the Xamarin.Forms Device class
+- How to use the IDeviceService instead of the Xamarin.Forms Device class

--- a/18-DeviceService/src/PrismSample.Android/MainApplication.cs
+++ b/18-DeviceService/src/PrismSample.Android/MainApplication.cs
@@ -5,7 +5,7 @@ using Android.Runtime;
 namespace PrismSample.Droid
 {
     [Application(
-        Label = "Prism Sample",
+        Label = "Device Service",
         Icon = "@mipmap/icon"
         )]
     public class MainApplication : Application

--- a/18-DeviceService/src/PrismSample/ViewModels/MainPageViewModel.cs
+++ b/18-DeviceService/src/PrismSample/ViewModels/MainPageViewModel.cs
@@ -1,11 +1,27 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Prism.Mvvm;
+﻿using Prism.Mvvm;
+using Prism.Services;
+using Xamarin.Forms;
 
 namespace PrismSample.ViewModels
 {
     public class MainPageViewModel : BindableBase
     {
+        private readonly IDeviceService _deviceService;
+
+        public string RuntimePlatform { get; set; }
+        public string Idiom { get; set; }
+        public string XamarinRuntimePlatform { get; set; }
+        public string XamarinIdiom { get; set; }
+
+        public MainPageViewModel(IDeviceService deviceService)
+        {
+            _deviceService = deviceService;
+
+            RuntimePlatform = _deviceService.RuntimePlatform.ToString();
+            Idiom = _deviceService.Idiom.ToString();
+            
+            XamarinIdiom = Device.Idiom.ToString();
+            XamarinRuntimePlatform = Device.RuntimePlatform;
+        }
     }
 }

--- a/18-DeviceService/src/PrismSample/ViewModels/MainPageViewModel.cs
+++ b/18-DeviceService/src/PrismSample/ViewModels/MainPageViewModel.cs
@@ -10,8 +10,6 @@ namespace PrismSample.ViewModels
 
         public string RuntimePlatform { get; set; }
         public string Idiom { get; set; }
-        public string XamarinRuntimePlatform { get; set; }
-        public string XamarinIdiom { get; set; }
 
         public MainPageViewModel(IDeviceService deviceService)
         {
@@ -19,9 +17,6 @@ namespace PrismSample.ViewModels
 
             RuntimePlatform = _deviceService.RuntimePlatform.ToString();
             Idiom = _deviceService.Idiom.ToString();
-            
-            XamarinIdiom = Device.Idiom.ToString();
-            XamarinRuntimePlatform = Device.RuntimePlatform;
         }
     }
 }

--- a/18-DeviceService/src/PrismSample/ViewModels/MainPageViewModel.cs
+++ b/18-DeviceService/src/PrismSample/ViewModels/MainPageViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Prism.Mvvm;
+﻿using Prism.AppModel;
+using Prism.Mvvm;
 using Prism.Services;
 using Xamarin.Forms;
 
@@ -8,15 +9,15 @@ namespace PrismSample.ViewModels
     {
         private readonly IDeviceService _deviceService;
 
-        public string RuntimePlatform { get; set; }
-        public string Idiom { get; set; }
+        public TargetIdiom Idiom { get; }
+        public RuntimePlatform RuntimePlatform { get; }
 
         public MainPageViewModel(IDeviceService deviceService)
         {
             _deviceService = deviceService;
 
-            RuntimePlatform = _deviceService.RuntimePlatform.ToString();
-            Idiom = _deviceService.Idiom.ToString();
+            RuntimePlatform = _deviceService.RuntimePlatform;
+            Idiom = _deviceService.Idiom;
         }
     }
 }

--- a/18-DeviceService/src/PrismSample/Views/MainPage.xaml
+++ b/18-DeviceService/src/PrismSample/Views/MainPage.xaml
@@ -7,10 +7,32 @@
              Title="Main Page"
              x:Class="PrismSample.Views.MainPage">
 
-    <StackLayout>
-        <Label Text="Welcome to Xamarin.Forms!" 
+  <StackLayout>
+    <Label Text="Welcome to Xamarin.Forms!" 
            HorizontalOptions="Center"
            VerticalOptions="CenterAndExpand" />
-    </StackLayout>
+
+    <Label Text="{Binding RuntimePlatform, StringFormat='Prism Runtime Platform: {0}'}"
+           HorizontalOptions="Center"
+           VerticalOptions="CenterAndExpand">
+    </Label>
+
+    <Label Text="{Binding Idiom, StringFormat='Prism Idiom: {0}'}"
+           HorizontalOptions="Center"
+           VerticalOptions="CenterAndExpand">
+    </Label>
+
+    <Label Text="{Binding XamarinRuntimePlatform, StringFormat='Xamarin Runtime Platform: {0}'}"
+           HorizontalOptions="Center"
+           VerticalOptions="CenterAndExpand">
+    </Label>
+
+    <Label Text="{Binding XamarinIdiom, StringFormat='Xamarin Idiom: {0}'}"
+           HorizontalOptions="Center"
+           VerticalOptions="CenterAndExpand">
+    </Label>
+
+
+  </StackLayout>
 
 </ContentPage>

--- a/18-DeviceService/src/PrismSample/Views/MainPage.xaml
+++ b/18-DeviceService/src/PrismSample/Views/MainPage.xaml
@@ -12,26 +12,15 @@
            HorizontalOptions="Center"
            VerticalOptions="CenterAndExpand" />
 
-    <Label Text="{Binding RuntimePlatform, StringFormat='Prism Runtime Platform: {0}'}"
+    <Label Text="{Binding RuntimePlatform, StringFormat='Runtime Platform: {0}'}"
            HorizontalOptions="Center"
            VerticalOptions="CenterAndExpand">
     </Label>
 
-    <Label Text="{Binding Idiom, StringFormat='Prism Idiom: {0}'}"
+    <Label Text="{Binding Idiom, StringFormat='Idiom: {0}'}"
            HorizontalOptions="Center"
            VerticalOptions="CenterAndExpand">
     </Label>
-
-    <Label Text="{Binding XamarinRuntimePlatform, StringFormat='Xamarin Runtime Platform: {0}'}"
-           HorizontalOptions="Center"
-           VerticalOptions="CenterAndExpand">
-    </Label>
-
-    <Label Text="{Binding XamarinIdiom, StringFormat='Xamarin Idiom: {0}'}"
-           HorizontalOptions="Center"
-           VerticalOptions="CenterAndExpand">
-    </Label>
-
 
   </StackLayout>
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Learn feature by feature how to use Prism in your apps!
 | 15 | [PageBehaviorFactory][15] | coming soon |
 | 16 | [PageLifecycleAware][16] | coming soon |
 | 17 | [XamlNavigation][17] | coming soon |
-| 18 | [DeviceService][18] | coming soon |
+| 18 | [DeviceService][18] | How to use Prism's IDeviceService to get the device's runtime and idiom. |
 | 19 | [NavigationMode][19] | coming soon |
 | 20 | [Confirm Navigation][20] | coming soon |
 


### PR DESCRIPTION
closes #60 

Use the IDeviceService to show the current Runtime and Idiom. I show both the Prism way and the Xamarin way as a comparison.