### PR TITLE
EventToCommand Behavior Sample implementation.

### DIFF
--- a/14-EventToCommandBehavior/ReadMe.md
+++ b/14-EventToCommandBehavior/ReadMe.md
@@ -1,6 +1,13 @@
 # EventToCommand Behavior
 
-TODO
+The EventToCommandBehavior class provide a convenient way to, in XAML, "bind" events to ICommand according to MVVM paradigm to avoid code behind. [Prism docs]
 
-- Should show use of the EventArgsPath
-- Should show use of a ValueConverter
+
+This sample project, shows you how to use couple of common usages of EventToCommandBehavior in Xamarin.Forms.
+
+* `Views/SimpleExamplePage` on this page you can find the simpliest way to use `EventToCommandBehavior` with `DelegateCommand`.
+
+* `Views/EventArgsConverterExamplePage` on this page you can find usage of `EventToCommandBehavior` in combination with `EventArgsConverter` property and `IValueConverter`.
+
+* `Views/EventArgsConverterExamplePage` on this page you can find usage of `EventToCommandBehavior` in combination with `EventArgsParameterPath` property and `Item` property.
+

--- a/14-EventToCommandBehavior/src/PrismSample/App.xaml.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/App.xaml.cs
@@ -17,7 +17,7 @@ namespace PrismSample
         {
             InitializeComponent();
 
-            var result = await NavigationService.NavigateAsync("MainPage");
+            var result = await NavigationService.NavigateAsync("NavigationPage/MainPage");
 
             if(!result.Success)
             {

--- a/14-EventToCommandBehavior/src/PrismSample/App.xaml.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/App.xaml.cs
@@ -3,6 +3,7 @@ using Prism.Ioc;
 using PrismSample.ViewModels;
 using PrismSample.Views;
 using Xamarin.Forms;
+using PrismSample.Services;
 
 namespace PrismSample
 {
@@ -28,6 +29,11 @@ namespace PrismSample
         {
             containerRegistry.RegisterForNavigation<NavigationPage>();
             containerRegistry.RegisterForNavigation<MainPage, MainPageViewModel>();
+            containerRegistry.Register<IDataProvider, MockDataProvider>();
+
+            containerRegistry.RegisterForNavigation<SimpleExamplePage, SimpleExamplePageViewModel>();
+            containerRegistry.RegisterForNavigation<EventArgsConverterExamplePage, EventArgsConverterExamplePageViewModel>();
+            containerRegistry.RegisterForNavigation<EventArgsParameterExamplePage, EventArgsExamplePageViewModel>();
         }
     }
 }

--- a/14-EventToCommandBehavior/src/PrismSample/Converters/ItemTappedEventArgsConverter.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/Converters/ItemTappedEventArgsConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using Xamarin.Forms;
+
+namespace PrismSample.Converters
+{
+    public class ItemTappedEventArgsConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(value is ItemTappedEventArgs itemTappedEventArgs))
+            {
+                throw new ArgumentException("Expected value to be of type ItemTappedEventArgs", nameof(value));
+            }
+
+            return itemTappedEventArgs.Item;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return new NotImplementedException();
+        }
+    }
+}

--- a/14-EventToCommandBehavior/src/PrismSample/Models/Developer.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/Models/Developer.cs
@@ -1,0 +1,8 @@
+﻿namespace PrismSample.Models
+{
+    public class Developer
+    {
+        public string FullName { get; set; }
+        public string Country { get; set; }
+    }
+}

--- a/14-EventToCommandBehavior/src/PrismSample/Services/IDataProvider.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/Services/IDataProvider.cs
@@ -1,0 +1,10 @@
+﻿using PrismSample.Models;
+using System.Collections.Generic;
+
+namespace PrismSample.Services
+{
+    public interface IDataProvider
+    {
+        List<Developer> GetAllData();
+    }
+}

--- a/14-EventToCommandBehavior/src/PrismSample/Services/MockDataProvider.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/Services/MockDataProvider.cs
@@ -1,0 +1,40 @@
+﻿using PrismSample.Models;
+using System.Collections.Generic;
+
+namespace PrismSample.Services
+{
+    public class MockDataProvider : IDataProvider
+    {
+        public List<Developer> GetAllData()
+        {
+            return new List<Developer>()
+            {
+                new Developer()
+                {
+                    FullName = "Brian Lagunas",
+                    Country = "United States"
+                },
+                new Developer()
+                {
+                    FullName = "Dan Siegel",
+                    Country = "United States"
+                },
+                new Developer()
+                {
+                    FullName = "Glenn Versweyveld",
+                    Country = "Belgium"
+                },
+                new Developer()
+                {
+                    FullName = "Hussain Abbasi",
+                    Country = "United States"
+                },
+                new Developer()
+                {
+                    FullName = "Almir Vuk",
+                    Country = "Bosnia and Herzegovina"
+                },
+            };
+        }
+    }
+}

--- a/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsConverterExamplePageViewModel.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsConverterExamplePageViewModel.cs
@@ -13,14 +13,14 @@ namespace PrismSample.ViewModels
 
         public ObservableCollection<Developer> Developers { get; set; }
 
-        private DelegateCommand<Developer> _selectedDeveloperCommand;
-        public DelegateCommand<Developer> SelectedDeveloperCommand => 
-            _selectedDeveloperCommand ?? (_selectedDeveloperCommand = new DelegateCommand<Developer>((developer) => SelectedDeveloper(developer)));
+        public DelegateCommand<Developer> SelectedDeveloperCommand { get; private set; }
 
         public EventArgsConverterExamplePageViewModel(IPageDialogService pageDialogService,
             IDataProvider dataProvider)
         {
             _pageDialogService = pageDialogService;
+
+            SelectedDeveloperCommand = new DelegateCommand<Developer>(SelectedDeveloper);
 
             // Insert test data into collection of Developers
             Developers = new ObservableCollection<Developer>();

--- a/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsConverterExamplePageViewModel.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsConverterExamplePageViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.ObjectModel;
-using System.Threading.Tasks;
 using PrismSample.Services;
 using PrismSample.Models;
 using Prism.Services;
@@ -16,7 +15,7 @@ namespace PrismSample.ViewModels
 
         private DelegateCommand<Developer> _selectedDeveloperCommand;
         public DelegateCommand<Developer> SelectedDeveloperCommand => 
-            _selectedDeveloperCommand ?? (_selectedDeveloperCommand = new DelegateCommand<Developer>(async (developer) => await SelectedDeveloper(developer)));
+            _selectedDeveloperCommand ?? (_selectedDeveloperCommand = new DelegateCommand<Developer>((developer) => SelectedDeveloper(developer)));
 
         public EventArgsConverterExamplePageViewModel(IPageDialogService pageDialogService,
             IDataProvider dataProvider)
@@ -31,7 +30,7 @@ namespace PrismSample.ViewModels
             }
         }
 
-        private async Task SelectedDeveloper(Developer developer)
+        private async void SelectedDeveloper(Developer developer)
         {
             await _pageDialogService.DisplayAlertAsync("Info", $"{developer.FullName} from {developer.Country} is selected.", "Ok");
         }

--- a/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsConverterExamplePageViewModel.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsConverterExamplePageViewModel.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using PrismSample.Services;
+using PrismSample.Models;
+using Prism.Services;
+using Prism.Commands;
+using Prism.Mvvm;
+
+namespace PrismSample.ViewModels
+{
+    public class EventArgsConverterExamplePageViewModel : BindableBase
+    {
+        private readonly IPageDialogService _pageDialogService;
+
+        public ObservableCollection<Developer> Developers { get; set; }
+
+        private DelegateCommand<Developer> _selectedDeveloperCommand;
+        public DelegateCommand<Developer> SelectedDeveloperCommand => 
+            _selectedDeveloperCommand ?? (_selectedDeveloperCommand = new DelegateCommand<Developer>(async (developer) => await SelectedDeveloper(developer)));
+
+        public EventArgsConverterExamplePageViewModel(IPageDialogService pageDialogService,
+            IDataProvider dataProvider)
+        {
+            _pageDialogService = pageDialogService;
+
+            // Insert test data into collection of Developers
+            Developers = new ObservableCollection<Developer>();
+            foreach (var developer in dataProvider.GetAllData())
+            {
+                Developers.Add(developer);
+            }
+        }
+
+        private async Task SelectedDeveloper(Developer developer)
+        {
+            await _pageDialogService.DisplayAlertAsync("Info", $"{developer.FullName} from {developer.Country} is selected.", "Ok");
+        }
+    }
+}

--- a/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsExamplePageViewModel.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsExamplePageViewModel.cs
@@ -13,13 +13,14 @@ namespace PrismSample.ViewModels
 
         public ObservableCollection<Developer> Developers { get; set; }
 
-        private DelegateCommand<Developer> _selectedDeveloperCommand;
-        public DelegateCommand<Developer> SelectedDeveloperCommand => _selectedDeveloperCommand ?? (_selectedDeveloperCommand = new DelegateCommand<Developer>((developer) => SelectedDeveloper(developer)));
+        public DelegateCommand<Developer> SelectedDeveloperCommand { get; private set; }
 
         public EventArgsExamplePageViewModel(IPageDialogService pageDialogService,
             IDataProvider dataProvider)
         {
             _pageDialogService = pageDialogService;
+
+            SelectedDeveloperCommand = new DelegateCommand<Developer>(SelectedDeveloper);
 
             // Insert test data into collection of Developers
             Developers = new ObservableCollection<Developer>();

--- a/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsExamplePageViewModel.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsExamplePageViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.ObjectModel;
-using System.Threading.Tasks;
 using PrismSample.Services;
 using PrismSample.Models;
 using Prism.Services;
@@ -15,7 +14,7 @@ namespace PrismSample.ViewModels
         public ObservableCollection<Developer> Developers { get; set; }
 
         private DelegateCommand<Developer> _selectedDeveloperCommand;
-        public DelegateCommand<Developer> SelectedDeveloperCommand => _selectedDeveloperCommand ?? (_selectedDeveloperCommand = new DelegateCommand<Developer>(async (developer) => await SelectedDeveloper(developer)));
+        public DelegateCommand<Developer> SelectedDeveloperCommand => _selectedDeveloperCommand ?? (_selectedDeveloperCommand = new DelegateCommand<Developer>((developer) => SelectedDeveloper(developer)));
 
         public EventArgsExamplePageViewModel(IPageDialogService pageDialogService,
             IDataProvider dataProvider)
@@ -30,7 +29,7 @@ namespace PrismSample.ViewModels
             }
         }
 
-        private async Task SelectedDeveloper(Developer developer)
+        private async void SelectedDeveloper(Developer developer)
         {
             await _pageDialogService.DisplayAlertAsync("Info", $"{developer.FullName} from {developer.Country} is selected.", "Ok");
         }

--- a/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsExamplePageViewModel.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsExamplePageViewModel.cs
@@ -30,7 +30,7 @@ namespace PrismSample.ViewModels
             }
         }
 
-        async Task SelectedDeveloper(Developer developer)
+        private async Task SelectedDeveloper(Developer developer)
         {
             await _pageDialogService.DisplayAlertAsync("Info", $"{developer.FullName} from {developer.Country} is selected.", "Ok");
         }

--- a/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsExamplePageViewModel.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/ViewModels/EventArgsExamplePageViewModel.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using PrismSample.Services;
+using PrismSample.Models;
+using Prism.Services;
+using Prism.Commands;
+using Prism.Mvvm;
+
+namespace PrismSample.ViewModels
+{
+    public class EventArgsExamplePageViewModel : BindableBase
+    {
+        private readonly IPageDialogService _pageDialogService;
+
+        public ObservableCollection<Developer> Developers { get; set; }
+
+        private DelegateCommand<Developer> _selectedDeveloperCommand;
+        public DelegateCommand<Developer> SelectedDeveloperCommand => _selectedDeveloperCommand ?? (_selectedDeveloperCommand = new DelegateCommand<Developer>(async (developer) => await SelectedDeveloper(developer)));
+
+        public EventArgsExamplePageViewModel(IPageDialogService pageDialogService,
+            IDataProvider dataProvider)
+        {
+            _pageDialogService = pageDialogService;
+
+            // Insert test data into collection of Developers
+            Developers = new ObservableCollection<Developer>();
+            foreach (var developer in dataProvider.GetAllData())
+            {
+                Developers.Add(developer);
+            }
+        }
+
+        async Task SelectedDeveloper(Developer developer)
+        {
+            await _pageDialogService.DisplayAlertAsync("Info", $"{developer.FullName} from {developer.Country} is selected.", "Ok");
+        }
+    }
+}

--- a/14-EventToCommandBehavior/src/PrismSample/ViewModels/MainPageViewModel.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/ViewModels/MainPageViewModel.cs
@@ -1,11 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Threading.Tasks;
+using PrismSample.Views;
+using Prism.Navigation;
+using Prism.Commands;
+using Xamarin.Forms;
 using Prism.Mvvm;
 
 namespace PrismSample.ViewModels
 {
     public class MainPageViewModel : BindableBase
     {
+        private readonly INavigationService _navigationService;
+
+        public DelegateCommand GoToEventArgsConverterExamplePageCommand { get; private set; }
+        public DelegateCommand GoToEventArgsParameterExamplePageCommand { get; private set; }
+        public DelegateCommand GoToSimpleExamplePageCommand { get; private set; }
+
+        public MainPageViewModel(INavigationService navigationService)
+        {
+            _navigationService = navigationService;
+
+            GoToEventArgsConverterExamplePageCommand = new DelegateCommand(async () => await GoToEventArgsConverterExamplePage());
+            GoToEventArgsParameterExamplePageCommand = new DelegateCommand(async () => await GoToEventArgsParameterExamplePage());
+            GoToSimpleExamplePageCommand = new DelegateCommand(async () => await GoToSimpleExamplePage());
+        }
+
+        private async Task GoToEventArgsConverterExamplePage()
+        {
+            await _navigationService.NavigateAsync(nameof(NavigationPage) + "/" + nameof(EventArgsConverterExamplePage));
+        }
+
+        private async Task GoToEventArgsParameterExamplePage()
+        {
+            await _navigationService.NavigateAsync(nameof(NavigationPage) + "/" + nameof(EventArgsParameterExamplePage));
+        }
+
+        private async Task GoToSimpleExamplePage()
+        {
+            await _navigationService.NavigateAsync(nameof(NavigationPage) + "/" + nameof(SimpleExamplePage));
+        }
     }
 }

--- a/14-EventToCommandBehavior/src/PrismSample/ViewModels/MainPageViewModel.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/ViewModels/MainPageViewModel.cs
@@ -1,7 +1,5 @@
-﻿using PrismSample.Views;
-using Prism.Navigation;
+﻿using Prism.Navigation;
 using Prism.Commands;
-using Xamarin.Forms;
 using Prism.Mvvm;
 
 namespace PrismSample.ViewModels
@@ -25,17 +23,17 @@ namespace PrismSample.ViewModels
 
         private async void GoToEventArgsConverterExamplePage()
         {
-            await _navigationService.NavigateAsync(nameof(NavigationPage) + "/" + nameof(EventArgsConverterExamplePage));
+            await _navigationService.NavigateAsync("EventArgsConverterExamplePage");
         }
 
         private async void GoToEventArgsParameterExamplePage()
         {
-            await _navigationService.NavigateAsync(nameof(NavigationPage) + "/" + nameof(EventArgsParameterExamplePage));
+            await _navigationService.NavigateAsync("EventArgsParameterExamplePage");
         }
 
         private async void GoToSimpleExamplePage()
         {
-            await _navigationService.NavigateAsync(nameof(NavigationPage) + "/" + nameof(SimpleExamplePage));
+            await _navigationService.NavigateAsync("SimpleExamplePage");
         }
     }
 }

--- a/14-EventToCommandBehavior/src/PrismSample/ViewModels/MainPageViewModel.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/ViewModels/MainPageViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using PrismSample.Views;
+﻿using PrismSample.Views;
 using Prism.Navigation;
 using Prism.Commands;
 using Xamarin.Forms;
@@ -19,22 +18,22 @@ namespace PrismSample.ViewModels
         {
             _navigationService = navigationService;
 
-            GoToEventArgsConverterExamplePageCommand = new DelegateCommand(async () => await GoToEventArgsConverterExamplePage());
-            GoToEventArgsParameterExamplePageCommand = new DelegateCommand(async () => await GoToEventArgsParameterExamplePage());
-            GoToSimpleExamplePageCommand = new DelegateCommand(async () => await GoToSimpleExamplePage());
+            GoToEventArgsConverterExamplePageCommand = new DelegateCommand(GoToEventArgsConverterExamplePage);
+            GoToEventArgsParameterExamplePageCommand = new DelegateCommand( GoToEventArgsParameterExamplePage);
+            GoToSimpleExamplePageCommand = new DelegateCommand(GoToSimpleExamplePage);
         }
 
-        private async Task GoToEventArgsConverterExamplePage()
+        private async void GoToEventArgsConverterExamplePage()
         {
             await _navigationService.NavigateAsync(nameof(NavigationPage) + "/" + nameof(EventArgsConverterExamplePage));
         }
 
-        private async Task GoToEventArgsParameterExamplePage()
+        private async void GoToEventArgsParameterExamplePage()
         {
             await _navigationService.NavigateAsync(nameof(NavigationPage) + "/" + nameof(EventArgsParameterExamplePage));
         }
 
-        private async Task GoToSimpleExamplePage()
+        private async void GoToSimpleExamplePage()
         {
             await _navigationService.NavigateAsync(nameof(NavigationPage) + "/" + nameof(SimpleExamplePage));
         }

--- a/14-EventToCommandBehavior/src/PrismSample/ViewModels/SimpleExamplePageViewModel.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/ViewModels/SimpleExamplePageViewModel.cs
@@ -31,7 +31,7 @@ namespace PrismSample.ViewModels
             }
         }
 
-        async Task SelectedDeveloper()
+        private async Task SelectedDeveloper()
         {
             await _pageDialogService.DisplayAlertAsync("Info.", "Some developer is selected.", "Ok");
         }

--- a/14-EventToCommandBehavior/src/PrismSample/ViewModels/SimpleExamplePageViewModel.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/ViewModels/SimpleExamplePageViewModel.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using PrismSample.Services;
+using PrismSample.Models;
+using Prism.Commands;
+using Prism.Services;
+using Prism.Mvvm;
+
+namespace PrismSample.ViewModels
+{
+    public class SimpleExamplePageViewModel : BindableBase
+    {
+        private readonly IPageDialogService _pageDialogService;
+
+        public DelegateCommand SelectedDeveloperCommand { get; private set; }
+
+        public ObservableCollection<Developer> Developers { get; set; }
+
+        public SimpleExamplePageViewModel(IPageDialogService pageDialogService, 
+            IDataProvider dataProvider)
+        {
+            _pageDialogService = pageDialogService;
+
+            SelectedDeveloperCommand = new DelegateCommand(async () => await SelectedDeveloper());
+
+            // Insert test data into collection of Developers
+            Developers = new ObservableCollection<Developer>();
+            foreach (var person in dataProvider.GetAllData())
+            {
+                Developers.Add(person);
+            }
+        }
+
+        async Task SelectedDeveloper()
+        {
+            await _pageDialogService.DisplayAlertAsync("Info.", "Some developer is selected.", "Ok");
+        }
+    }
+}

--- a/14-EventToCommandBehavior/src/PrismSample/ViewModels/SimpleExamplePageViewModel.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/ViewModels/SimpleExamplePageViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.ObjectModel;
-using System.Threading.Tasks;
 using PrismSample.Services;
 using PrismSample.Models;
 using Prism.Commands;
@@ -21,7 +20,7 @@ namespace PrismSample.ViewModels
         {
             _pageDialogService = pageDialogService;
 
-            SelectedDeveloperCommand = new DelegateCommand(async () => await SelectedDeveloper());
+            SelectedDeveloperCommand = new DelegateCommand(SelectedDeveloper);
 
             // Insert test data into collection of Developers
             Developers = new ObservableCollection<Developer>();
@@ -31,7 +30,7 @@ namespace PrismSample.ViewModels
             }
         }
 
-        private async Task SelectedDeveloper()
+        private async void SelectedDeveloper()
         {
             await _pageDialogService.DisplayAlertAsync("Info.", "Some developer is selected.", "Ok");
         }

--- a/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsConverterExamplePage.xaml
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsConverterExamplePage.xaml
@@ -3,9 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="PrismSample.Views.EventArgsConverterExamplePage"
              Title="Event Args Converter Example"
-             
              xmlns:c="clr-namespace:PrismSample.Converters"
-             xmlns:b="http://prismlibrary.com">
+             xmlns:prism="http://prismlibrary.com">
 
   <ContentPage.Resources>
     <ResourceDictionary>
@@ -24,11 +23,10 @@
     </ListView.ItemTemplate>
 
     <ListView.Behaviors>
-      <b:EventToCommandBehavior EventName="ItemTapped" 
-                                Command="{Binding SelectedDeveloperCommand}"
-                                EventArgsConverter="{StaticResource itemTappedEventArgsConverter}" />
+      <prism:EventToCommandBehavior EventName="ItemTapped" 
+                                    Command="{Binding SelectedDeveloperCommand}"
+                                    EventArgsConverter="{StaticResource itemTappedEventArgsConverter}" />
     </ListView.Behaviors>
-
   </ListView>
 
 </ContentPage>

--- a/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsConverterExamplePage.xaml
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsConverterExamplePage.xaml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="PrismSample.Views.EventArgsConverterExamplePage"
+             Title="Event Args Converter Example"
+             
+             xmlns:c="clr-namespace:PrismSample.Converters"
+             xmlns:b="clr-namespace:Prism.Behaviors;assembly=Prism.Forms">
+
+  <ContentPage.Resources>
+    <ResourceDictionary>
+      <c:ItemTappedEventArgsConverter x:Key="itemTappedEventArgsConverter" />
+    </ResourceDictionary>
+  </ContentPage.Resources>
+  
+  <ContentPage.Content>
+
+    <ListView ItemsSource="{Binding Developers}">
+      <ListView.ItemTemplate>
+        <DataTemplate>
+          
+          <TextCell Text="{Binding FullName}"
+                    Detail="{Binding Country}" />
+        
+        </DataTemplate>
+      </ListView.ItemTemplate>
+
+      <ListView.Behaviors>
+        <b:EventToCommandBehavior EventName="ItemTapped" 
+                                  Command="{Binding SelectedDeveloperCommand}"
+                                  EventArgsConverter="{StaticResource itemTappedEventArgsConverter}" />
+      </ListView.Behaviors>
+
+    </ListView>
+
+  </ContentPage.Content>
+</ContentPage>

--- a/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsConverterExamplePage.xaml
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsConverterExamplePage.xaml
@@ -5,33 +5,30 @@
              Title="Event Args Converter Example"
              
              xmlns:c="clr-namespace:PrismSample.Converters"
-             xmlns:b="clr-namespace:Prism.Behaviors;assembly=Prism.Forms">
+             xmlns:b="http://prismlibrary.com">
 
   <ContentPage.Resources>
     <ResourceDictionary>
       <c:ItemTappedEventArgsConverter x:Key="itemTappedEventArgsConverter" />
     </ResourceDictionary>
   </ContentPage.Resources>
-  
-  <ContentPage.Content>
 
-    <ListView ItemsSource="{Binding Developers}">
-      <ListView.ItemTemplate>
-        <DataTemplate>
-          
-          <TextCell Text="{Binding FullName}"
-                    Detail="{Binding Country}" />
-        
-        </DataTemplate>
-      </ListView.ItemTemplate>
+  <ListView ItemsSource="{Binding Developers}">
+    <ListView.ItemTemplate>
+      <DataTemplate>
 
-      <ListView.Behaviors>
-        <b:EventToCommandBehavior EventName="ItemTapped" 
-                                  Command="{Binding SelectedDeveloperCommand}"
-                                  EventArgsConverter="{StaticResource itemTappedEventArgsConverter}" />
-      </ListView.Behaviors>
+        <TextCell Text="{Binding FullName}"
+                  Detail="{Binding Country}" />
 
-    </ListView>
+      </DataTemplate>
+    </ListView.ItemTemplate>
 
-  </ContentPage.Content>
+    <ListView.Behaviors>
+      <b:EventToCommandBehavior EventName="ItemTapped" 
+                                Command="{Binding SelectedDeveloperCommand}"
+                                EventArgsConverter="{StaticResource itemTappedEventArgsConverter}" />
+    </ListView.Behaviors>
+
+  </ListView>
+
 </ContentPage>

--- a/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsConverterExamplePage.xaml.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsConverterExamplePage.xaml.cs
@@ -1,9 +1,7 @@
-﻿using Xamarin.Forms.Xaml;
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 
 namespace PrismSample.Views
 {
-    [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class EventArgsConverterExamplePage : ContentPage
     {
         public EventArgsConverterExamplePage()

--- a/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsConverterExamplePage.xaml.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsConverterExamplePage.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Xamarin.Forms.Xaml;
+using Xamarin.Forms;
+
+namespace PrismSample.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class EventArgsConverterExamplePage : ContentPage
+    {
+        public EventArgsConverterExamplePage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsParameterExamplePage.xaml
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsParameterExamplePage.xaml
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="PrismSample.Views.EventArgsParameterExamplePage"
+             Title="Event Args Example"
+             
+             xmlns:b="clr-namespace:Prism.Behaviors;assembly=Prism.Forms">
+
+  <ContentPage.Content>
+
+    <ListView ItemsSource="{Binding Developers}">
+      <ListView.ItemTemplate>
+        <DataTemplate>
+
+          <TextCell Text="{Binding FullName}"
+                    Detail="{Binding Country}" />
+
+        </DataTemplate>
+      </ListView.ItemTemplate>
+
+      <ListView.Behaviors>
+        <b:EventToCommandBehavior EventName="ItemTapped" 
+                                  Command="{Binding SelectedDeveloperCommand}"
+                                  EventArgsParameterPath="Item" />
+      </ListView.Behaviors>
+
+    </ListView>
+
+  </ContentPage.Content>
+</ContentPage>

--- a/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsParameterExamplePage.xaml
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsParameterExamplePage.xaml
@@ -3,8 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="PrismSample.Views.EventArgsParameterExamplePage"
              Title="Event Args Parameter Example"
-             
-             xmlns:b="http://prismlibrary.com">
+             xmlns:prism="http://prismlibrary.com">
 
   <ListView ItemsSource="{Binding Developers}">
     <ListView.ItemTemplate>
@@ -17,11 +16,10 @@
     </ListView.ItemTemplate>
 
     <ListView.Behaviors>
-      <b:EventToCommandBehavior EventName="ItemTapped" 
-                                Command="{Binding SelectedDeveloperCommand}"
-                                EventArgsParameterPath="Item" />
+      <prism:EventToCommandBehavior EventName="ItemTapped" 
+                                    Command="{Binding SelectedDeveloperCommand}"
+                                    EventArgsParameterPath="Item" />
     </ListView.Behaviors>
-
   </ListView>
 
 </ContentPage>

--- a/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsParameterExamplePage.xaml
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsParameterExamplePage.xaml
@@ -2,29 +2,26 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="PrismSample.Views.EventArgsParameterExamplePage"
-             Title="Event Args Example"
+             Title="Event Args Parameter Example"
              
-             xmlns:b="clr-namespace:Prism.Behaviors;assembly=Prism.Forms">
+             xmlns:b="http://prismlibrary.com">
 
-  <ContentPage.Content>
+  <ListView ItemsSource="{Binding Developers}">
+    <ListView.ItemTemplate>
+      <DataTemplate>
 
-    <ListView ItemsSource="{Binding Developers}">
-      <ListView.ItemTemplate>
-        <DataTemplate>
-
-          <TextCell Text="{Binding FullName}"
+        <TextCell Text="{Binding FullName}"
                     Detail="{Binding Country}" />
 
-        </DataTemplate>
-      </ListView.ItemTemplate>
+      </DataTemplate>
+    </ListView.ItemTemplate>
 
-      <ListView.Behaviors>
-        <b:EventToCommandBehavior EventName="ItemTapped" 
-                                  Command="{Binding SelectedDeveloperCommand}"
-                                  EventArgsParameterPath="Item" />
-      </ListView.Behaviors>
+    <ListView.Behaviors>
+      <b:EventToCommandBehavior EventName="ItemTapped" 
+                                Command="{Binding SelectedDeveloperCommand}"
+                                EventArgsParameterPath="Item" />
+    </ListView.Behaviors>
 
-    </ListView>
+  </ListView>
 
-  </ContentPage.Content>
 </ContentPage>

--- a/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsParameterExamplePage.xaml.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsParameterExamplePage.xaml.cs
@@ -1,9 +1,7 @@
-﻿using Xamarin.Forms.Xaml;
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 
 namespace PrismSample.Views
 {
-    [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class EventArgsParameterExamplePage : ContentPage
     {
         public EventArgsParameterExamplePage()

--- a/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsParameterExamplePage.xaml.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/EventArgsParameterExamplePage.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Xamarin.Forms.Xaml;
+using Xamarin.Forms;
+
+namespace PrismSample.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class EventArgsParameterExamplePage : ContentPage
+    {
+        public EventArgsParameterExamplePage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/14-EventToCommandBehavior/src/PrismSample/Views/MainPage.xaml
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/MainPage.xaml
@@ -5,12 +5,21 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              Title="Main Page"
-             x:Class="PrismSample.Views.MainPage">
+             x:Class="PrismSample.Views.MainPage"
+  
+             xmlns:prism="clr-namespace:Prism.Navigation.Xaml;assembly=Prism.Forms">
 
-    <StackLayout>
-        <Label Text="Welcome to Xamarin.Forms!" 
-           HorizontalOptions="Center"
-           VerticalOptions="CenterAndExpand" />
-    </StackLayout>
+  <StackLayout Margin="16" VerticalOptions="Center">
+
+    <Button Text="Simple Example" 
+            Command="{prism:NavigateTo 'NavigationPage/SimpleExamplePage'}"/>
+
+    <Button Text="IValueConverter Example" 
+            Command="{prism:NavigateTo 'NavigationPage/EventArgsConverterExamplePage'}"/>
+
+    <Button Text="Event Args Parameter Path Example" 
+            Command="{prism:NavigateTo 'NavigationPage/EventArgsParameterExamplePage'}"/>
+
+  </StackLayout>
 
 </ContentPage>

--- a/14-EventToCommandBehavior/src/PrismSample/Views/MainPage.xaml
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/MainPage.xaml
@@ -5,20 +5,18 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              Title="Main Page"
-             x:Class="PrismSample.Views.MainPage"
-  
-             xmlns:prism="clr-namespace:Prism.Navigation.Xaml;assembly=Prism.Forms">
+             x:Class="PrismSample.Views.MainPage">
 
   <StackLayout Margin="16" VerticalOptions="Center">
 
     <Button Text="Simple Example" 
-            Command="{prism:NavigateTo 'NavigationPage/SimpleExamplePage'}"/>
+            Command="{Binding GoToSimpleExamplePageCommand}"/>
 
     <Button Text="IValueConverter Example" 
-            Command="{prism:NavigateTo 'NavigationPage/EventArgsConverterExamplePage'}"/>
+            Command="{Binding GoToEventArgsConverterExamplePageCommand}"/>
 
     <Button Text="Event Args Parameter Path Example" 
-            Command="{prism:NavigateTo 'NavigationPage/EventArgsParameterExamplePage'}"/>
+            Command="{Binding GoToEventArgsParameterExamplePageCommand}"/>
 
   </StackLayout>
 

--- a/14-EventToCommandBehavior/src/PrismSample/Views/SimpleExamplePage.xaml
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/SimpleExamplePage.xaml
@@ -4,26 +4,23 @@
              x:Class="PrismSample.Views.SimpleExamplePage"
              Title="Simple usage"
              
-             xmlns:b="clr-namespace:Prism.Behaviors;assembly=Prism.Forms">
+             xmlns:b="http://prismlibrary.com">
 
-  <ContentPage.Content>
+  <ListView ItemsSource="{Binding Developers}">
+    <ListView.ItemTemplate>
+      <DataTemplate>
 
-    <ListView ItemsSource="{Binding Developers}">
-      <ListView.ItemTemplate>
-        <DataTemplate>
+        <TextCell Text="{Binding FullName}"
+                  Detail="{Binding Country}" />
 
-          <TextCell Text="{Binding FullName}"
-                    Detail="{Binding Country}" />
+      </DataTemplate>
+    </ListView.ItemTemplate>
 
-        </DataTemplate>
-      </ListView.ItemTemplate>
+    <ListView.Behaviors>
+      <b:EventToCommandBehavior EventName="ItemTapped" 
+                                Command="{Binding SelectedDeveloperCommand}" />
+    </ListView.Behaviors>
 
-      <ListView.Behaviors>
-        <b:EventToCommandBehavior EventName="ItemTapped" 
-                                  Command="{Binding SelectedDeveloperCommand}" />
-      </ListView.Behaviors>
+  </ListView>
 
-    </ListView>
-
-  </ContentPage.Content>
 </ContentPage>

--- a/14-EventToCommandBehavior/src/PrismSample/Views/SimpleExamplePage.xaml
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/SimpleExamplePage.xaml
@@ -3,8 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="PrismSample.Views.SimpleExamplePage"
              Title="Simple usage"
-             
-             xmlns:b="http://prismlibrary.com">
+             xmlns:prism="http://prismlibrary.com">
 
   <ListView ItemsSource="{Binding Developers}">
     <ListView.ItemTemplate>
@@ -17,10 +16,9 @@
     </ListView.ItemTemplate>
 
     <ListView.Behaviors>
-      <b:EventToCommandBehavior EventName="ItemTapped" 
-                                Command="{Binding SelectedDeveloperCommand}" />
+      <prism:EventToCommandBehavior EventName="ItemTapped" 
+                                    Command="{Binding SelectedDeveloperCommand}" />
     </ListView.Behaviors>
-
   </ListView>
 
 </ContentPage>

--- a/14-EventToCommandBehavior/src/PrismSample/Views/SimpleExamplePage.xaml
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/SimpleExamplePage.xaml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="PrismSample.Views.SimpleExamplePage"
+             Title="Simple usage"
+             
+             xmlns:b="clr-namespace:Prism.Behaviors;assembly=Prism.Forms">
+
+  <ContentPage.Content>
+
+    <ListView ItemsSource="{Binding Developers}">
+      <ListView.ItemTemplate>
+        <DataTemplate>
+
+          <TextCell Text="{Binding FullName}"
+                    Detail="{Binding Country}" />
+
+        </DataTemplate>
+      </ListView.ItemTemplate>
+
+      <ListView.Behaviors>
+        <b:EventToCommandBehavior EventName="ItemTapped" 
+                                  Command="{Binding SelectedDeveloperCommand}" />
+      </ListView.Behaviors>
+
+    </ListView>
+
+  </ContentPage.Content>
+</ContentPage>

--- a/14-EventToCommandBehavior/src/PrismSample/Views/SimpleExamplePage.xaml.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/SimpleExamplePage.xaml.cs
@@ -1,9 +1,7 @@
 ﻿using Xamarin.Forms;
-using Xamarin.Forms.Xaml;
 
 namespace PrismSample.Views
 {
-    [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class SimpleExamplePage : ContentPage
     {
         public SimpleExamplePage()

--- a/14-EventToCommandBehavior/src/PrismSample/Views/SimpleExamplePage.xaml.cs
+++ b/14-EventToCommandBehavior/src/PrismSample/Views/SimpleExamplePage.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace PrismSample.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class SimpleExamplePage : ContentPage
+    {
+        public SimpleExamplePage()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
[[Update] 14 EventToCommandBehavior #56](https://github.com/PrismLibrary/Prism-Samples-Forms/issues/56)

I have implemented this EventToCommand Behaviour sample using three standard examples. 
 
Page(s): 
* EventArgsConverterExamplePage
* SimpleExamplePage
* EventArgsParameterExamplePage

Model(s) (test data model for showing data in the list):
* Developer 

Converter(s):
* ItemTappedEventArgsConverter

This project sample is showing how to use EventToCommand Behavior in three simple examples, on pages with `ListView `and SelectedItem commands in the `ViewModel `part.

Let me know if there is a need to change and edit something.