### PR TITLE
Removing parentheses from the HandleCallback Action.

### DIFF
--- a/07-DialogService/ReadMe.md
+++ b/07-DialogService/ReadMe.md
@@ -81,7 +81,7 @@ _dialogService.ShowDialog("LockingDialog", new DialogParameters
 ```
 Show the dialog and handle callback,
 ```csharp
-_dialogService.ShowDialog("TermsDialog", new DialogParameters(), HandleCallback());
+_dialogService.ShowDialog("TermsDialog", new DialogParameters(), HandleCallback);
 
 private void HandleCallback(IDialogResult result)
 {...}


### PR DESCRIPTION
There is a tiny typo I noticed while looking into the DialogService sample:  The parentheses next to the HandleCallback argument of `_dialogService.ShowDialog` call should not be there in order to make the subsequent handler (`HandleCallback(IDialogResult result)`) valid.

I know this is the tiniest issue ever... But I'm pretty excited about making my first ever PR to an open source project, and one that I love dearly! Please do not hesitate to let me know if I've messed up this PR in any way.