### PR TITLE
Sample fixes

### DIFF
--- a/05-EventAggregator/src/PrismSample.Android/MainActivity.cs
+++ b/05-EventAggregator/src/PrismSample.Android/MainActivity.cs
@@ -1,6 +1,10 @@
 ﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
+using Prism.Ioc;
+using Prism.Events;
+using PrismSample.Models;
+using Android.Widget;
 
 namespace PrismSample.Droid
 {

--- a/05-EventAggregator/src/PrismSample.UWP/MainPage.xaml.cs
+++ b/05-EventAggregator/src/PrismSample.UWP/MainPage.xaml.cs
@@ -12,6 +12,10 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
+using Prism.Ioc;
+using Prism.Events;
+using PrismSample.Models;
+using Windows.UI.Popups;
 
 namespace PrismSample.UWP
 {
@@ -21,7 +25,7 @@ namespace PrismSample.UWP
         {
             this.InitializeComponent();
 
-            var application = new PrismSample.App(this);
+            var application = new PrismSample.App();
 
             var ea = application.Container.Resolve<IEventAggregator>().GetEvent<NativeEvent>().Subscribe(OnNativeEvent);
 
@@ -32,11 +36,6 @@ namespace PrismSample.UWP
         {
             var msg = new MessageDialog($"Hi {args.Message}, from Windows");
             await msg.ShowAsync();
-        }
-
-        public void RegisterTypes(IContainerRegistry containerRegistry)
-        {
-
         }
     }
 }

--- a/05-EventAggregator/src/PrismSample.iOS/AppDelegate.cs
+++ b/05-EventAggregator/src/PrismSample.iOS/AppDelegate.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using Foundation;
+using Prism.Events;
+using Prism.Ioc;
+using PrismSample.Models;
 using UIKit;
 
 namespace PrismSample.iOS

--- a/sample-apps/ContosoCookbook/ContosoCookbook/ContosoCookbook/ViewModels/MainPageViewModel.cs
+++ b/sample-apps/ContosoCookbook/ContosoCookbook/ContosoCookbook/ViewModels/MainPageViewModel.cs
@@ -15,7 +15,7 @@ namespace ContosoCookbook.ViewModels
         {
             _navigationService = navigationService;
             _recipeService = recipeService;
-            RecipeSelectedCommand = new DelegateCommand<Recipe>(RecipeSelected);
+            RecipeSelectedCommand = new DelegateCommand<Recipe>(RecipeSelected, _ => !IsBusy).ObservesProperty(() => IsBusy);
         }
 
         public DelegateCommand<Recipe> RecipeSelectedCommand { get; }
@@ -27,14 +27,23 @@ namespace ContosoCookbook.ViewModels
             set => SetProperty(ref _recipeGroups, value);
         }
 
+        private bool _isBusy;
+        public bool IsBusy
+        {
+            get => _isBusy;
+            set => SetProperty(ref _isBusy, value);
+        }
+
         private async void RecipeSelected(Recipe recipe)
         {
+            IsBusy = true;
             var p = new NavigationParameters
             {
                 { "recipe", recipe }
             };
 
             await _navigationService.NavigateAsync("RecipePage", p);
+            IsBusy = false;
         }
 
         public override async void Initialize(INavigationParameters parameters)


### PR DESCRIPTION
# Description

- Updates the ContosoCookbook so that the DelegateCommand used to navigate takes a CanExecute delegate and observes an IsBusy Property - fixes #92 
- Adds missing namespaces from the IEventAggregator sample - fixes #89