### PR TITLE
Updating EventAggregator sample

### DIFF
--- a/05-EventAggregator/src/PrismSample/Navigation/NavigationParameterKeys.cs
+++ b/05-EventAggregator/src/PrismSample/Navigation/NavigationParameterKeys.cs
@@ -1,0 +1,7 @@
+﻿namespace PrismSample.Navigation
+{
+    public static class NavigationParameterKeys
+    {
+        public const string CurrentIsFunValue = "CurrentIsFunValue";
+    }
+}

--- a/05-EventAggregator/src/PrismSample/ViewModels/DataEntryPageViewModel.cs
+++ b/05-EventAggregator/src/PrismSample/ViewModels/DataEntryPageViewModel.cs
@@ -4,6 +4,7 @@ using Prism.Commands;
 using Prism.Events;
 using Prism.Navigation;
 using PrismSample.Models;
+using PrismSample.Navigation;
 
 namespace PrismSample
 {
@@ -33,6 +34,15 @@ namespace PrismSample
         private void OnSubmitTapped()
         {
             _navigationService.GoBackAsync ();
+        }
+
+        public override void OnNavigatedTo(INavigationParameters parameters)
+        {
+            base.OnNavigatedTo(parameters);
+            if (parameters.ContainsKey(NavigationParameterKeys.CurrentIsFunValue))
+            {
+                IsFun = (bool)parameters[NavigationParameterKeys.CurrentIsFunValue];
+            }
         }
     }
 }

--- a/05-EventAggregator/src/PrismSample/ViewModels/DataEntryPageViewModel.cs
+++ b/05-EventAggregator/src/PrismSample/ViewModels/DataEntryPageViewModel.cs
@@ -38,10 +38,9 @@ namespace PrismSample
 
         public override void OnNavigatedTo(INavigationParameters parameters)
         {
-            base.OnNavigatedTo(parameters);
             if (parameters.ContainsKey(NavigationParameterKeys.CurrentIsFunValue))
             {
-                IsFun = (bool)parameters[NavigationParameterKeys.CurrentIsFunValue];
+                IsFun = parameters.GetValue<bool>(NavigationParameterKeys.CurrentIsFunValue);
             }
         }
     }

--- a/05-EventAggregator/src/PrismSample/ViewModels/HomePageViewModel.cs
+++ b/05-EventAggregator/src/PrismSample/ViewModels/HomePageViewModel.cs
@@ -48,7 +48,11 @@ namespace PrismSample
 
         private void OnEntryCommandTapped()
         {
-            _navigationService.NavigateAsync(Navigate.DataEntry);
+            INavigationParameters parameters = new NavigationParameters
+            {
+                {NavigationParameterKeys.CurrentIsFunValue, IsFun}
+            };
+            _navigationService.NavigateAsync(Navigate.DataEntry, parameters);
         }
 
         public ICommand GoBackCommand { get; }

--- a/05-EventAggregator/src/PrismSample/ViewModels/HomePageViewModel.cs
+++ b/05-EventAggregator/src/PrismSample/ViewModels/HomePageViewModel.cs
@@ -48,11 +48,7 @@ namespace PrismSample
 
         private void OnEntryCommandTapped()
         {
-            INavigationParameters parameters = new NavigationParameters
-            {
-                {NavigationParameterKeys.CurrentIsFunValue, IsFun}
-            };
-            _navigationService.NavigateAsync(Navigate.DataEntry, parameters);
+            _navigationService.NavigateAsync(Navigate.DataEntry, (NavigationParameterKeys.CurrentIsFunValue, IsFun));
         }
 
         public ICommand GoBackCommand { get; }


### PR DESCRIPTION
The way this sample was, the `IsFun` property of the `DataEntryPageViewModel` defaulted to the false/off position no matter what the switch was set to on the `HomePageViewModel`. With these proposed changes, the current value of `IsFun` is passed to the `DataEntryPageViewModel` to reflect the current value, rather than always defaulting to false. 

I believe this makes the app more logical and predictable, now that the `IsFun` property of the `HomePageViewModel` will always reflect the value displayed on the `DataEntryPageViewModel`:

Old Behavior | New Behavior
------------- | ------
| <ol><li>Launch app</li><li>Tap "XAMARIN.FORMS EVENTS"</li><li>Tap "PROVIDE FEEDBACK"</li><li>Set the "Isn't this fun?" switch to true/on</li><li>Tap "SUBMIT"</li><li>Note switch in the true/on position now on `HomePage`</li><li>Tap "PROVIDE FEEDBACK" again</li><li>**Note switch on the `DataEntryPage` is in the false/off position, which does not reflect the value on the `HomePage`**</li></ol> | <ol><li>Launch app</li><li>Tap "XAMARIN.FORMS EVENTS"</li><li>Tap "PROVIDE FEEDBACK"</li><li>Set the "Isn't this fun?" switch to true/on</li><li>Tap "SUBMIT"</li><li>Note switch in the true/on position now on `HomePage`</li><li>Tap "PROVIDE FEEDBACK" again</li><li>**Note switch on the `DataEntryPage` is in the true/on position, accurately reflecting the value on the `HomePage` and allowing the user to set the switch to the false/off position which will update the `HomePage` value as well**</li></ol> |