### PR TITLE
fix DialogService sample's binding errors (incl. false alarms)

### DIFF
--- a/07-DialogService/src/PrismSample/Dialogs/ContactSelectorDialog.xaml
+++ b/07-DialogService/src/PrismSample/Dialogs/ContactSelectorDialog.xaml
@@ -2,6 +2,7 @@
 <Frame xmlns="http://xamarin.com/schemas/2014/forms"
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
        xmlns:prism="http://prismlibrary.com"
+       xmlns:models="clr-namespace:PrismSample.Models"
        prism:DialogLayout.RelativeWidthRequest="0.75"
        prism:DialogLayout.RelativeHeightRequest="0.75"
        prism:DialogLayout.CloseOnBackgroundTapped="True"
@@ -18,7 +19,7 @@
               SelectionMode="Single"
               SeparatorColor="Gray">
       <ListView.ItemTemplate>
-        <DataTemplate>
+        <DataTemplate x:DataType="models:Contact">
           <ViewCell>
             <Grid ColumnSpacing="10" Margin="8">
               <Grid.ColumnDefinitions>

--- a/07-DialogService/src/PrismSample/Dialogs/ContactSelectorDialogViewModel.cs
+++ b/07-DialogService/src/PrismSample/Dialogs/ContactSelectorDialogViewModel.cs
@@ -9,23 +9,31 @@ namespace PrismSample.ViewModels
     public class ContactSelectorDialogViewModel : BaseViewModel, IDialogAware
     {
         private readonly IContactsService _contactsService;
-        
+
         public ContactSelectorDialogViewModel(IContactsService contactsService)
         {
             _contactsService = contactsService;
         }
-        
+
+        // note: acting upon search query is not implemented
+        private string _query;
+        public string Query
+        {
+            get => _query;
+            set => SetProperty(ref _query, value);
+        }
+
         private List<Contact> _contacts;
         public List<Contact> Contacts
         {
             get => _contacts;
             set => SetProperty(ref _contacts, value);
         }
-        
+
         private Contact _selectedContact;
         public Contact SelectedContact
         {
-            get => _selectedContact; 
+            get => _selectedContact;
             set => SetProperty(ref _selectedContact, value, onChanged:OnContactSelected);
         }
 
@@ -39,9 +47,9 @@ namespace PrismSample.ViewModels
         {
             Contacts = await _contactsService.GetContacts();
         }
-        
+
         public bool CanCloseDialog() => true;
-        public void OnDialogClosed() { }       
+        public void OnDialogClosed() { }
         public event Action<IDialogParameters> RequestClose;
     }
 }


### PR DESCRIPTION
I noticed that the DialogService sample had a number of debug console error messages about binding errors for the contact selector dialog (in UWP at least).  So, I added a x:DataType to the appropriate DataTemplate element, which got rid of most of the (false-alarm) messages.  One message remained, which was about a true binding error; ContactSelectorDialogViewModel did not have a Query property, so I added it.

I think having a x:DataType for all DataTemplates is a good idea.  Would y'all be interested in another pull request where I try to add a x:DataType to every DataTemplate in this repo?